### PR TITLE
Fix for rounding undefined db runtime payload value

### DIFF
--- a/rails_panel/assets/javascripts/transactions.js
+++ b/rails_panel/assets/javascripts/transactions.js
@@ -48,7 +48,7 @@ function TransactionsCtrl($scope) {
     switch(data.name) {
     case "process_action.action_controller":
       data.payload.other_runtime = function() {
-        var sum = data.payload.db_runtime.round() + data.payload.view_runtime.round()
+        var sum = (data.payload.db_runtime ? data.payload.db_runtime.round() : 0) + data.payload.view_runtime.round()
         return data.duration.round() - sum;
       }();
       $scope.requestsMap[key] = data;


### PR DESCRIPTION
This fixes the broken rounding of db runtime payload value in the chrome extension. I don't know why the problem occurs but I'm guessing it might be because I'm using Mongo DB. It would be better if a fix could be done in the gem instead.
