### PR TITLE
Support apps that run under a root (ie /my_app

### DIFF
--- a/meta_request/lib/meta_request/middlewares/headers.rb
+++ b/meta_request/lib/meta_request/middlewares/headers.rb
@@ -12,6 +12,7 @@ module MetaRequest
         request_path = env['PATH_INFO']
         middleware = Rack::ResponseHeaders.new(@app) do |headers|
           headers['X-Meta-Request-Version'] = MetaRequest::VERSION unless request_path.start_with?(assets_prefix)
+          headers['X-Meta-Request-Root'] = env['SCRIPT_NAME'] unless request_path.start_with?(assets_prefix)
         end
         middleware.call(env)
       end

--- a/rails_panel/assets/javascripts/panel.js
+++ b/rails_panel/assets/javascripts/panel.js
@@ -31,10 +31,17 @@ $(function() {
         headers = request.response.headers;
         var requestId = headers.find(function(x) { return x.name == 'X-Request-Id' });
         var metaRequestVersion = headers.find(function(x) { return x.name == 'X-Meta-Request-Version' });
+        var metaRequestRoot = headers.find(function(x) { return x.name == 'X-Meta-Request-Root' });
+
         if (typeof metaRequestVersion != 'undefined') {
 
+          var root = "";
+          if (typeof metaRequestRoot != 'undefined') {
+            root = metaRequestRoot.value;
+          }
+
           var uri = new URI(request.request.url);
-          uri.pathname('/__meta_request/' + requestId.value + '.json');
+          uri.pathname(root + '/__meta_request/' + requestId.value + '.json');
 
           chrome_getJSON(uri.toString(), function(data) {
             addData(requestId.value, scope, data);


### PR DESCRIPTION
We use apache in development so requests need to go to /my_app/__meta_request.

This change sets the "root" as a response header, and uses that header in the XHR URI for __meta_request, if it's there, otherwise defaults to old behavior
