### PR TITLE
added 'emacs' as an editor option

### DIFF
--- a/rails_panel/assets/javascripts/filters.js
+++ b/rails_panel/assets/javascripts/filters.js
@@ -2,9 +2,10 @@ angular.module('RailsPanel', []).
   filter('editorify', function() {
     return function(input) {
       var mapping = {
-        mvim: "mvim://open?url=file://%s&line=%d&column=%d", 
+        mvim: "mvim://open?url=file://%s&line=%d&column=%d",
         mate: "txmt://open?url=file://%s&line=%d&column=%d",
-        subl: "subl://open?url=file://%s&line=%d&column=%d"}
+        subl: "subl://open?url=file://%s&line=%d&column=%d",
+        emacs: "emacs://open?url=file://%s&line=%d&column=%d"}
       var editor = localStorage.getItem("railspanel.editor");
       var editorPrefix = mapping[editor]
       var out = sprintf(editorPrefix, input, 1, 1);
@@ -16,4 +17,3 @@ angular.module('RailsPanel', []).
       return input.remove(/.*\/app\/views/);
     }
   });
-

--- a/rails_panel/options.html
+++ b/rails_panel/options.html
@@ -30,10 +30,15 @@
             (<a href="https://github.com/asuth/subl-handler" target="_blank">requires subl-handler</a>)
           </small>
         </label>
+        <label class="radio">
+          <input type="radio" name="storage.editor" value="emacs" ng-model="editor">
+          Emacs
+          <small>
+            (<a href="https://github.com/typester/emacs-handler" target="_blank">requires emacs-handler</a>)
+          </small>
+        </label>
       </form>
       <div class="footer">Developed by <a href="http://rors.org" target="_blank">Dejan Simic</a></div>
-
     </div>
   </body>
 </html>
-


### PR DESCRIPTION
Similar to sublime text, emacs requires an external URL handler, see: https://github.com/typester/emacs-handler.

I added emacs to the supported editors mapping in filters.js and added emacs as a selectable option in options.html.

BTW -- thanks so much for Rails Panel, its cool!

ian.
