### PR TITLE
Fixes issue #11

### DIFF
--- a/rails_panel/panel.html
+++ b/rails_panel/panel.html
@@ -103,7 +103,7 @@
                   <tr>
                     <th data-sort="string">Type</th>
                     <th data-sort="string">SQL</th>
-                    <th data-sort="float" class="duration">Duration</th>
+                    <th data-sort="float" class="duration">Duration (ms)</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -121,7 +121,7 @@
                 <thead>
                   <tr>
                     <th data-sort="string">View</th>
-                    <th data-sort="float" class="duration">Duration</th>
+                    <th data-sort="float" class="duration">Duration (ms)</th>
                   </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
Appended units of (ms) to the Duration column heading, under the assumption that the values displayed are always in milliseconds.
