### PR TITLE
Add `emacs` into editor options.

### DIFF
--- a/rails_panel/assets/javascripts/filters.js
+++ b/rails_panel/assets/javascripts/filters.js
@@ -4,7 +4,8 @@ angular.module('RailsPanel', []).
       var mapping = {
         mvim: "mvim://open?url=file://%s&line=%d&column=%d", 
         mate: "txmt://open?url=file://%s&line=%d&column=%d",
-        subl: "subl://open?url=file://%s&line=%d&column=%d"}
+        subl: "subl://open?url=file://%s&line=%d&column=%d",
+        emacs: "emacs://open?url=file://%s&line=%d&column=%d"}
       var editor = localStorage.getItem("railspanel.editor");
       var editorPrefix = mapping[editor]
       var out = sprintf(editorPrefix, input, 1, 1);

--- a/rails_panel/options.html
+++ b/rails_panel/options.html
@@ -30,6 +30,13 @@
             (<a href="https://github.com/asuth/subl-handler" target="_blank">requires subl-handler</a>)
           </small>
         </label>
+        <label class="radio">
+          <input type="radio" name="storage.editor" value="emacs" ng-model="editor">
+          Emacs
+          <small>
+            (<a href="https://github.com/typester/emacs-handler" target="_blank">requires emacs-handler</a>)
+          </small>
+        </label>
       </form>
       <div class="footer">Developed by <a href="http://rors.org" target="_blank">Dejan Simic</a></div>
 


### PR DESCRIPTION
Emacs can be opened via `emacs://...` using [emacs-handler](https://github.com/typester/emacs-handler). Since Sublime Text has been supported using subl-handler, Emacs deserves to be supported, I think ;)
