### PR TITLE
Depend of railties instead of rails

### DIFF
--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Supporting gem for Rails Panel (Google Chrome extension for Rails development)}
   gem.homepage      = "https://github.com/dejan/rails_panel/tree/master/meta_request"
 
-  gem.add_dependency('rails')
+  gem.add_dependency('railties')
   gem.add_dependency('rack-contrib')
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Rails depend of ActiveRecord, ActiveResource more than railties. This both gem not needed by this gem. So you can avoid this dependency.

If you use a project without this dependency meta_request add it.
