### PR TITLE
Change middleware to support rails app in subfolders

### DIFF
--- a/meta_request/lib/meta_request/middlewares/meta_request_handler.rb
+++ b/meta_request/lib/meta_request/middlewares/meta_request_handler.rb
@@ -6,7 +6,7 @@ module MetaRequest
       end
 
       def call(env)
-        request_id = env["PATH_INFO"][%r{^/__meta_request/(.+)\.json$}, 1]
+        request_id = env["PATH_INFO"][%r{/__meta_request/(.+)\.json$}, 1]
         if request_id
           events_json(request_id)
         else

--- a/meta_request/test/meta_request/middlewares/meta_request_handler_test.rb
+++ b/meta_request/test/meta_request/middlewares/meta_request_handler_test.rb
@@ -24,6 +24,14 @@ describe MetaRequest::Middlewares::MetaRequestHandler do
     end
   end
 
+  describe 'meta request call within a subfolder' do
+    it 'responds with json file' do
+      env = {'PATH_INFO' => '/any/subfolder/__meta_request/1234.json'}
+      response = @middleware.call(env)
+      assert_equal [200, { "Content-Type" => "text/plain; charset=utf-8" }, ['abcdef']], response
+    end
+  end
+
   after do
     FileUtils.rm_rf "#{Dir.pwd}/tmp"
   end

--- a/rails_panel/assets/javascripts/panel.js
+++ b/rails_panel/assets/javascripts/panel.js
@@ -49,7 +49,8 @@ $(function() {
         if (request.response.status === 500 || typeof metaRequestVersion != 'undefined') {
 
           var uri = new URI(request.request.url);
-          uri.pathname('/__meta_request/' + requestId.value + '.json');
+		  var path = uri.pathname() + '/__meta_request/' + requestId.value + '.json';
+          uri.pathname(path);
           uri.search("");
           chrome_getJSON(uri.toString(), function(data) {
             addData(requestId.value, scope, data);


### PR DESCRIPTION
If two applications run on the same domain

first_rails_app -> in http:://any_domain/
second_rails_app -> in http://any_domain/seccond_application

and the rails_panel was used then "meta_request" from the second app should be called.

To provide this the regular expression for the call-Method should listen on any "__meta_request" string on any page and the rails_panel should call the method on the current url path.
