### PR TITLE
Change Dir.pwd to Rails.root due to tmp files sometimes getting stored in other folders

### DIFF
--- a/meta_request/lib/meta_request/storage.rb
+++ b/meta_request/lib/meta_request/storage.rb
@@ -37,7 +37,7 @@ module MetaRequest
     end
 
     def dir_path
-      File.join(Dir.pwd, 'tmp', 'data', 'meta_request')
+      File.join(Rails.root, 'tmp', 'data', 'meta_request')
     end
   end
 end

--- a/meta_request/test/meta_request/storage_test.rb
+++ b/meta_request/test/meta_request/storage_test.rb
@@ -21,6 +21,6 @@ describe MetaRequest::Storage do
   end
 
   after do
-    FileUtils.rm_rf "#{Dir.pwd}/tmp"
+    FileUtils.rm_rf "#{Rails.root}/tmp"
   end
 end

--- a/meta_request/test/test_helper.rb
+++ b/meta_request/test/test_helper.rb
@@ -3,3 +3,9 @@ require 'bundler/setup'
 require 'meta_request'
 require 'minitest/autorun'
 require 'minitest/mock'
+
+module Rails
+  def self.root
+    Dir.pwd
+  end
+end


### PR DESCRIPTION
Thanks for building this gem -- it is great.  I have an app that reads and writes to the file system, specifically I read in a bunch of classes from a folder.  This sets Dir to not be the same as the Rails.root directory and causes all of the meta_request data to be stored inside of this folder in lieu of Rails.root/tmp.  I imagine I am not alone in this need to talk to the file system.  I have proposed a change that uses Rails.root in lieu of Dir.pwd to set the head of the data storage path.  Please let me know if you have any questions or concerns about merging this request.
