### PR TITLE
support lowercased headers

### DIFF
--- a/rails_panel/assets/javascripts/panel.js
+++ b/rails_panel/assets/javascripts/panel.js
@@ -44,8 +44,8 @@ $(function() {
     chrome.devtools.network.onRequestFinished.addListener(
       function(request) {
         headers = request.response.headers;
-        var requestId = headers.find(function(x) { return x.name == 'X-Request-Id' });
-        var metaRequestVersion = headers.find(function(x) { return x.name == 'X-Meta-Request-Version' });
+        var requestId = headers.find(function(x) { return x.name.toLowerCase() == 'x-request-id' });
+        var metaRequestVersion = headers.find(function(x) { return x.name.toLowerCase() == 'x-meta-request-version' });
         if (request.response.status === 500 || typeof metaRequestVersion != 'undefined') {
           if (typeof metaRequestVersion != 'undefined') {
             if (metaRequestVersion.value < '0.2.4') {


### PR DESCRIPTION
Hi Dejan, I found that when using pow my headers were lowercased, what was the cause for my rails application not being recognized by rails_panel. This ofcourse fixes the problem.
