### PR TITLE
Ignore cached queries in RailsPanel

### DIFF
--- a/rails_panel/assets/javascripts/transactions.js
+++ b/rails_panel/assets/javascripts/transactions.js
@@ -96,7 +96,7 @@ function TransactionsCtrl($scope) {
       $scope.pushToMap($scope.logsMap, key, data);
       break;
     case "sql.active_record":
-      if (data.payload.name !== "SCHEMA") {
+      if (data.payload.name !== "SCHEMA" && data.payload.name !== "CACHE") {
         $scope.pushToMap($scope.sqlsMap, key, data);
       }
       break;


### PR DESCRIPTION
Don't add cached queries when creating the map of queries.

Quick fix for issue #30, although I did not find that issue before creating this.
