### PR TITLE
Fix: use `detect` instead of `select{}.first`

### DIFF
--- a/meta_request/lib/meta_request/app_notifications.rb
+++ b/meta_request/lib/meta_request/app_notifications.rb
@@ -8,7 +8,7 @@ module MetaRequest
         subscribe("meta_request.log").
         subscribe("sql.active_record") do |*args|
           name, start, ending, transaction_id, payload = args
-          dev_caller = caller.select { |c| c=~/#{Rails.root}/}.first
+          dev_caller = caller.detect { |c| c=~/#{Rails.root}/ }
           if dev_caller
             c = Callsite.parse(dev_caller)
             payload.merge!(:line => c.line, :filename => c.filename, :method => c.method)


### PR DESCRIPTION
`select` iterates over each object while `detect` stops on first match and so it does not allocates so many string objects and is faster.
