### PR TITLE
Add background color to panel, make usable with dark dev tools themes

### DIFF
--- a/rails_panel/assets/stylesheets/panel.css
+++ b/rails_panel/assets/stylesheets/panel.css
@@ -2,6 +2,10 @@
   -webkit-box-sizing: border-box;
 }
 
+body.rails-panel {
+  background: #fff;
+}
+
 .data-grid {
   border: none;
   position: absolute;
@@ -13,7 +17,7 @@
 
 #tabs, table, tbody, tr, th, .data-grid {
   -webkit-touch-callout: none;
-}  
+}
 
 .data-grid table {
   table-layout: fixed;
@@ -66,7 +70,7 @@ table#requests td {
 }
 
 .data-container tr {
-  height: 28px; 
+  height: 28px;
 }
 
 .data-container tr.filler {
@@ -291,7 +295,7 @@ ul.tabbed-pane-header-tabs {
   text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
   white-space: nowrap;
   display:block;
-  padding: 0 10px; 
+  padding: 0 10px;
   text-align: center;
 }
 
@@ -371,5 +375,5 @@ table#breakdown td.meter-col {
 }
 
 
- 
+
 

--- a/rails_panel/panel.html
+++ b/rails_panel/panel.html
@@ -23,7 +23,7 @@
     <script src="assets/javascripts/init.js"></script>
 
   </head>
-  <body>
+  <body class="rails-panel">
     <div class="split-view" ng-controller='TransactionsCtrl'>
       <div class="split-view-contents split-view-contents-requests">
         <div class="data-grid data-grid-requests">
@@ -86,7 +86,7 @@
                 </li>
               </ul>
             </div>
-          </div> 
+          </div>
 
 
           <div class="tabbed-pane-content data-grid data-grid-details">


### PR DESCRIPTION
### Whats Up?

When using a dark dev tools theme, the background of rails panel is transparent, so you get black text on a dark background rendering it unusable.
### What changed?
- Add a class to the rails panel body element, to avoid naming collisions
- Give the rails panel body element a background color of `#fff`
### Example of issue

Before:

![screen shot 2014-12-02 at 8 29 25 am](https://cloud.githubusercontent.com/assets/1007571/5266853/4e1b8fe6-7a01-11e4-8d98-b5868da8cef3.png)

After:

![screen shot 2014-12-02 at 8 46 48 am](https://cloud.githubusercontent.com/assets/1007571/5266858/55e1763c-7a01-11e4-9a97-c4c839db23e2.png)

This is an integral chrome extension when working with rails, seriously great work.
