### PR TITLE
use a frozen copy of Rails.root in AppNotifications and LogInterceptor

### DIFF
--- a/meta_request/lib/meta_request.rb
+++ b/meta_request/lib/meta_request.rb
@@ -10,6 +10,12 @@ module MetaRequest
   def self.logger
     @@logger ||= Logger.new(File.join(Rails.root, 'log', 'meta_request.log'))
   end
+
+  # stash a frozen copy away so we're not allocating a new string over and over
+  # again in AppNotifications and LogInterceptor
+  def self.rails_root
+    @@rails_root ||= Rails.root.to_s.freeze
+  end
 end
 
 require "meta_request/railtie"

--- a/meta_request/lib/meta_request/app_notifications.rb
+++ b/meta_request/lib/meta_request/app_notifications.rb
@@ -8,7 +8,7 @@ module MetaRequest
         subscribe("meta_request.log").
         subscribe("sql.active_record") do |*args|
           name, start, ending, transaction_id, payload = args
-          dev_caller = caller.detect { |c| c=~/#{Rails.root}/ }
+          dev_caller = caller.detect { |c| c.include? MetaRequest.rails_root }
           if dev_caller
             c = Callsite.parse(dev_caller)
             payload.merge!(:line => c.line, :filename => c.filename, :method => c.method)

--- a/meta_request/lib/meta_request/log_interceptor.rb
+++ b/meta_request/lib/meta_request/log_interceptor.rb
@@ -32,11 +32,11 @@ module MetaRequest
       push_event(:unknown, message)
       super
     end
-    
-    
+
+
     private
     def push_event(level, message)
-      dev_log = AppRequest.current && caller[1] =~ /#{Rails.root}/
+      dev_log = AppRequest.current && caller[1].include?(MetaRequest.rails_root)
       if dev_log
         c = Callsite.parse(caller[1])
         payload = {:message => message, :level => level, :line => c.line, :filename => c.filename, :method => c.method}


### PR DESCRIPTION
i was playing with https://github.com/schneems/derailed_benchmarks while debugging a memory leak in an application and i saw that meta_request was allocating a lot of memory:

``````
$ bundle exec rake -f perf.rake perf:mem RAILS_ENV=development
Booting: development
Running 1 times
Total allocated 155114
Total retained 1160

allocated memory by gem
-----------------------------------
meta_request-0.3.4 x 17136862
activesupport-4.1.8 x 700213
haml-4.0.6 x 346715
actionview-4.1.8 x 328915
ruby-2.1.5/lib x 327681```
``````

the specific culprits were:

```
allocated memory by location
-----------------------------------
gems/meta_request-0.3.4/lib/meta_request/app_notifications.rb:11 x 13325502
gems/meta_request-0.3.4/lib/meta_request/log_interceptor.rb:39 x 3758621
```

both of which involve converting `Rails.root` from a `Pathname` into a `String`. 

this change adds a `MetaRequest.rails_root` method which caches a frozen copy of `Rails.root.to_s` and drops the total memory allocation of a rails boot to 40% of the previous value:

```
Booting: development
Running 1 times
Total allocated 67646
Total retained 1217

allocated memory by gem
-----------------------------------
meta_request/lib x 6846874
activesupport-4.1.8 x 700143
haml-4.0.6 x 346420
actionview-4.1.8 x 328915
ruby-2.1.5/lib x 327681

allocated memory by location
-----------------------------------
git/rails_panel/meta_request/lib/meta_request/log_interceptor.rb:39 x 3663501
git/rails_panel/meta_request/lib/meta_request/app_notifications.rb:11 x 3130480
```
