### PR TITLE
Fix CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - CI_HOME=`pwd`/meta_request
 install: 
+  - sh -c 'gem install bundler'
   - sh -c 'cd meta_request && bundle install'
   - sh -c 'cd meta_request/test/functional/rails-4.1.4 && bundle install'
 script:  sh -c 'cd meta_request && make'

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/json'
 require 'active_support/core_ext'
 


### PR DESCRIPTION
## uninitialized constant ActiveSupport::Autoload
Requiring `active_support` before `active_support/core_ext` is necessary.

## NoMethodError: undefined method `spec' for nil:NilClass
Update bundler's version before bundle install.
https://github.com/bundler/bundler/issues/3558