### PR TITLE
follow the Rails 5 specification

### DIFF
--- a/meta_request/lib/meta_request/middlewares/app_request_handler.rb
+++ b/meta_request/lib/meta_request/middlewares/app_request_handler.rb
@@ -13,7 +13,11 @@ module MetaRequest
         @app.call(env)
       rescue Exception => exception
         if defined?(ActionDispatch::ExceptionWrapper)
-          wrapper = ActionDispatch::ExceptionWrapper.new(env, exception)
+          wrapper = if ActionDispatch::ExceptionWrapper.method_defined? :env
+                      ActionDispatch::ExceptionWrapper.new(env, exception)
+                    else
+                      ActionDispatch::ExceptionWrapper.new(env['action_dispatch.backtrace_cleaner'], exception)
+                    end
           app_request.events.push(*Event.events_for_exception(wrapper))
         else
           app_request.events.push(*Event.events_for_exception(exception))


### PR DESCRIPTION
`ActionDispatch::ExceptionWrapper.new`'s first argument is `backtrace_cleaner` instead of `env` in Rails 5.

SEE ALSO:
https://github.com/rails/rails/commit/6d85804bc6aeecce5669fb4b0d7b33c069deff3a