### PR TITLE
This adds support for the text editor Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RailsPanel
 ===========
 
-RailsPanel is a Chrome extension for Rails development that will end your tailing of development.log. Have all information about your Rails app requests in the browser - in the Developer Tools panel. Provides insight to db/rendering/total times, parameter list, rendered views and more. 
+RailsPanel is a Chrome extension for Rails development that will end your tailing of development.log. Have all information about your Rails app requests in the browser - in the Developer Tools panel. Provides insight to db/rendering/total times, parameter list, rendered views and more.
 
 ![railspanel](https://cloud.githubusercontent.com/assets/4494/3090049/917e5378-e586-11e3-9bd4-1db232968126.png)
 
@@ -15,11 +15,11 @@ group :development do
 end
 ```
 
-Install RailsPanel extension from the [Chrome WebStore](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing extension, since it will auto-update on every new version. Note that you still need to update meta_request gem yourself. 
+Install RailsPanel extension from the [Chrome WebStore](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing extension, since it will auto-update on every new version. Note that you still need to update meta_request gem yourself.
 
 ## Install unpacked version
 
-If you have a problem installing extension from Chrome Store or just want to run latest and hack on it, just clone the repo (say under ~/workspace/rails_panel) and in "Developer mode" Chrome Extensions page select "Load Unpacked extension..." and select "~/workspace/rails_panel/rails_panel". 
+If you have a problem installing extension from Chrome Store or just want to run latest and hack on it, just clone the repo (say under ~/workspace/rails_panel) and in "Developer mode" Chrome Extensions page select "Load Unpacked extension..." and select "~/workspace/rails_panel/rails_panel".
 
 ## Supported environments
 
@@ -33,7 +33,8 @@ Select your editor on the extension options page: chrome://extensions. Following
 * MacVim
 * TextMate
 * Sublime
-* Emacs 
+* Emacs
+* Atom 
 * RubyMine
 
 ## Compatibility Warnings

--- a/rails_panel/assets/javascripts/filters.js
+++ b/rails_panel/assets/javascripts/filters.js
@@ -14,6 +14,7 @@ angular.module('RailsPanel', [])
         subl: "subl://open?url=file://%s&line=%d&column=%d",
         sblm: "sblm:///%s",
         emacs: "emacs://open?url=file://%s&line=%d&column=%d",
+        atom: "atm://open?url=file://%s&line=%d&column=%d",
         mine: "rubymine://open?url=file://%s&line=%d"}
       var editor = localStorage.getItem("railspanel.editor");
       var editorPrefix = mapping[editor]
@@ -29,7 +30,7 @@ angular.module('RailsPanel', [])
     }
   }).
   filter('normalizePath', function() {
-    return function(input) {      
+    return function(input) {
       return input.remove(/.*\/app\//);
     }
   }).

--- a/rails_panel/options.html
+++ b/rails_panel/options.html
@@ -45,6 +45,13 @@
           </small>
         </label>
         <label class="radio">
+          <input type="radio" name="storage.editor" value="atom" ng-model="editor">
+          Atom
+          <small>
+            (<a href="https://github.com/WizardOfOgz/atom-handler" target="_blank">requires atom-handler</a>)
+          </small>
+        </label>
+        <label class="radio">
             <input type="radio" name="storage.editor" value="mine" ng-model="editor">
             RubyMine
             <small>


### PR DESCRIPTION
Adds support for the text editor Atom, via [atom-handler](https://github.com/WizardOfOgz/atom-handler), as suggested by @zenry.

Three small changes were required:

1. A radio button is added to the chrome extension's options. It has a link to atom-handler.
<img width="427" alt="screen shot 2016-01-29 at 10 36 15 pm" src="https://cloud.githubusercontent.com/assets/10853895/12694172/c9743b0a-c6d8-11e5-89ed-1b42a1ed2d4c.png">
2. The mapping hash of editorPrefixes was extended to include the [textmate style URL](https://github.com/WizardOfOgz/atom-handler#examples) for atom-handler.
3. The repo's README.md was updated to reflect support for Atom.



Merging this request closes #82 