### PR TITLE
add cache tab, fix rendering of color logging

### DIFF
--- a/rails_panel/assets/javascripts/transactions.js
+++ b/rails_panel/assets/javascripts/transactions.js
@@ -9,6 +9,7 @@ function TransactionsCtrl($scope) {
   $scope.sqlsMap             = {}; // {transactionKey: [{...}, {...}], ... }
   $scope.sqlsCachedCountMap  = {}; // {transactionKey: count, ...}
   $scope.showCachedSqls      = true;
+  $scope.cachesMap           = {}; // {transactionKey: [{...}, {...}], ... }
 
   $scope.expectedMetaRequestVersion = '0.3.4'
   $scope.metaRequestVersion  = $scope.expectedMetaRequestVersion;
@@ -24,7 +25,7 @@ function TransactionsCtrl($scope) {
       return request;
     });
   }
-  
+
   $scope.activeKey = null;
 
   $scope.clear = function() {
@@ -36,8 +37,9 @@ function TransactionsCtrl($scope) {
     $scope.paramsMap = {};
     $scope.sqlsMap = {};
     $scope.activeKey = null;
+    $scope.cachesMap = {};
   }
-  
+
   $scope.activeRequest = function() {
     return $scope.requestsMap[$scope.activeKey];
   }
@@ -66,7 +68,11 @@ function TransactionsCtrl($scope) {
   $scope.activeSqls = function() {
     return $scope.sqlsMap[$scope.activeKey];
   }
-  
+
+  $scope.activeCaches = function() {
+    return $scope.cachesMap[$scope.activeKey];
+  }
+
   $scope.showQuery = function(type) {
     return $scope.showCachedSqls || type !== "CACHE";
   }
@@ -77,8 +83,8 @@ function TransactionsCtrl($scope) {
     } else {
       return col.length > 0;
     }
-  } 
-  
+  }
+
   $scope.activeParams = function() {
     return $scope.paramsMap[$scope.activeKey];
   }
@@ -119,7 +125,7 @@ function TransactionsCtrl($scope) {
         return data.durationRounded - data.payload.dbRuntimeRounded - data.payload.viewRuntimeRounded;
       }();
       $scope.requestsMap[key] = data;
-      Object.keys(data.payload.params).each(function(n) { 
+      Object.keys(data.payload.params).each(function(n) {
         $scope.pushToMap($scope.paramsMap, key, {name:n, value:data.payload.params[n]});
       });
       $scope.transactionKeys.push(key);
@@ -152,6 +158,14 @@ function TransactionsCtrl($scope) {
         $scope.sqlsCachedCountMap[key] = val;
       }
       break;
+    case "cache_read.active_support":
+    case "cache_generate.active_support":
+    case "cache_fetch_hit.active_support":
+    case "cache_write.active_support":
+    case "cache_delete.active_support":
+    case "cache_exist?.active_support":
+      $scope.pushToMap($scope.cachesMap, key, data);
+      break;
     default:
       console.log('Notification not supported:' + data.name);
     }
@@ -162,7 +176,7 @@ function TransactionsCtrl($scope) {
     if (typeof value == 'undefined') {
       map[key] = [data];
     } else {
-      value.push(data) 
+      value.push(data)
     }
   }
 

--- a/rails_panel/panel.html
+++ b/rails_panel/panel.html
@@ -79,6 +79,9 @@
                   <a href="#tab-views" class="tabbed-pane-header-tab-title">Rendering</a>
                 </li>
                 <li class="tabbed-pane-header-tab">
+                  <a href="#tab-cache" class="tabbed-pane-header-tab-title">Cache</a>
+                </li>
+                <li class="tabbed-pane-header-tab">
                   <a href="#tab-log" class="tabbed-pane-header-tab-title">Log</a>
                 </li>
                 <li class="tabbed-pane-header-tab">
@@ -186,6 +189,34 @@
                 </tbody>
               </table>
             </div>
+            <div id="tab-cache">
+              <table class="stupidtable" id="cache"  ng-show="notEmpty(activeCaches())">
+                <thead>
+                  <tr>
+                    <th data-sort="string">Location</th>
+                    <th data-sort="string">Type</th>
+                    <th data-sort="string">Key</th>
+                    <th class="fluid">Options</th>
+                    <th data-sort="string">Hit</th>
+                    <th data-sort="float" class="duration">Duration</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr ng-repeat="cache in activeCaches()" class="{{cache.payload.name}}">
+                    <td>
+                      <span ng-show="cache.payload.filename != undefined && cache.payload.line != undefined">
+                        <a href="{{cache.payload.filename | editorify:cache.payload.line }}">{{cache.payload.filename | normalizePath}}:{{cache.payload.line}}</a>
+                      </span>
+                    </td>
+                    <td>{{cache.payload.type}}</td>
+                    <td>{{cache.payload.key}}</td>
+                    <td>{{cache.payload.options}}</td>
+                    <td>{{cache.payload.hit}}</td>
+                    <td class="duration" data-sort-value="{{-cache.duration}}">{{cache.duration | number:0}} ms</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
             <div id="tab-log">
               <table id="log" ng-show="notEmpty(activeLog())">
                 <thead>
@@ -197,7 +228,7 @@
                 <tbody>
                   <tr ng-repeat="log in activeLog()">
                     <td><a href="{{log.payload.filename | editorify:log.payload.line}}">{{log.payload.filename | normalizePath}}:{{log.payload.line}}</a></td>
-                    <td>{{log.payload.message | sanitize | ansi2html}}</td>
+                    <td ng-bind-html-unsafe="log.payload.message | sanitize | ansi2html"></td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
1. add a tab for active_support cache instrumentation 
2. fix bug where html generated from `ansi2html` wouldn't be rendered - i tested this by logging html and something in color and the html remains escaped while the added colors are converted to html and rendered correctly. 