### PR TITLE
Don't override method signatures of base logger

### DIFF
--- a/meta_request/lib/meta_request/log_interceptor.rb
+++ b/meta_request/lib/meta_request/log_interceptor.rb
@@ -3,33 +3,33 @@ require 'callsite'
 module MetaRequest
   module LogInterceptor
 
-    def debug(message = nil, &block)
-      push_event(:debug, message)
+    def debug(*message)
+      push_event(:debug, message.join(' '))
       super
     end
 
-    def info(message = nil, &block)
-      push_event(:info, message)
+    def info(*message)
+      push_event(:info, message.join(' '))
       super
     end
 
-    def warn(message = nil, &block)
-      push_event(:warn, message)
+    def warn(*message)
+      push_event(:warn, message.join(' '))
       super
     end
 
-    def error(message = nil, &block)
-      push_event(:error, message)
+    def error(*message)
+      push_event(:error, message.join(' '))
       super
     end
 
-    def fatal(message = nil, &block)
-      push_event(:fatal, message)
+    def fatal(*message)
+      push_event(:fatal, message.join(' '))
       super
     end
 
-    def unknown(message = nil, &block)
-      push_event(:unknown, message)
+    def unknown(*message)
+      push_event(:unknown, message.join(' '))
       super
     end
 

--- a/meta_request/lib/meta_request/log_interceptor.rb
+++ b/meta_request/lib/meta_request/log_interceptor.rb
@@ -3,33 +3,33 @@ require 'callsite'
 module MetaRequest
   module LogInterceptor
 
-    def debug(*message)
-      push_event(:debug, message.join(' '))
+    def debug(message=nil, *args)
+      push_event(:debug, message)
       super
     end
 
-    def info(*message)
-      push_event(:info, message.join(' '))
+    def info(message=nil, *args)
+      push_event(:info, message)
       super
     end
 
-    def warn(*message)
-      push_event(:warn, message.join(' '))
+    def warn(message=nil, *args)
+      push_event(:warn, message)
       super
     end
 
-    def error(*message)
-      push_event(:error, message.join(' '))
+    def error(message=nil, *args)
+      push_event(:error, message)
       super
     end
 
-    def fatal(*message)
-      push_event(:fatal, message.join(' '))
+    def fatal(message=nil, *args)
+      push_event(:fatal, message)
       super
     end
 
-    def unknown(*message)
-      push_event(:unknown, message.join(' '))
+    def unknown(message=nil, *args)
+      push_event(:unknown, message)
       super
     end
 


### PR DESCRIPTION
When extending `Rails.logger` with `MetaRequest::LogInterceptor`, the method signature of the
base logger should be preserved, rather than limiting to a single argument.  Some logging classes
allow multiple arguments *and* can serve as `Logger` substitutes, and `LogInterceptor` is breaking
other callers to those logging classes.

An example error:

```ruby
{
  :exception => "ArgumentError",
  :message   => "wrong number of arguments (given 2, expected 0..1)",
  :backtrace => [
    [ 0] "gems/meta_request-0.3.4/lib/meta_request/log_interceptor.rb:11:in `info'",
  ]
}
```

This pull request passes the argument list to the original class unmodified, which fixes the issue we are experiencing.

Thanks for considering this PR.  ~~Some additional work may be needed to ensure all tests still pass on all Ruby versions that matter to MetaRequest.~~  It looks like the Travis CI tests passed.