### PR TITLE
Make it possible to initialize meta_request in an initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ You can clear the panel with the usual shortcuts of ⌘+k or ctrl+l.
 
 [![CircleCI](https://circleci.com/gh/dejan/rails_panel.svg?style=svg&circle-token=56cf52dd2729102bb9b6e23d5e2fcc8eff0875b3)](https://circleci.com/gh/dejan/rails_panel)
 
+## Conditional alternative initialization
+
+If you do not want to enable meta_request every time you start the server you can put it like this in your app's Gemfile:
+
+```ruby
+group :development do
+  gem 'meta_request', require: false
+end
+```
+
+Then create an initializer that determines the condition to initialize meta_request:
+
+```ruby
+  # In `config/initializers/benchmarking.rb` (for example)
+  if ENV['USE_RAILS_PANEL']
+    require 'meta_request'
+
+    # Initialize manually since we skipped it in the Gemfile
+    MetaRequest::initialize!(Rails.application)
+  end
+```
+
+This way you can turn meta_request on and off through environment variables. This is useful for projects with different people or when you don't need it every time you work on your app.
+
 ## Licence
 
 Copyright (c) 2012 Dejan Simic

--- a/meta_request/lib/meta_request/railtie.rb
+++ b/meta_request/lib/meta_request/railtie.rb
@@ -1,27 +1,60 @@
 require 'rails/railtie'
 
 module MetaRequest
+  def self.initialize!(app)
+    raise "MetaRequest initialized twice. Set `require: false' for meta_request in your Gemfile" if @already_initialized
+
+    MetaRequest::inject_middlewares!(app)
+    MetaRequest::initialize_log_interceptor!
+    MetaRequest::subscribe_to_notifications!
+
+    @already_initialized = true
+  end
+
+  def self.inject_middlewares!(app)
+    raise "MetaRequest middlewares injected twice. Set `require: false' for meta_request in your Gemfile" if @injected_middlewares
+
+    app.middleware.use Middlewares::RequestId unless defined?(ActionDispatch::RequestId)
+    app.middleware.use Middlewares::MetaRequestHandler
+
+    if defined? ActionDispatch::DebugExceptions
+      app.middleware.insert_before ActionDispatch::DebugExceptions, Middlewares::Headers, app.config
+    else
+      app.middleware.use Middlewares::Headers, app.config
+    end
+
+    app.middleware.use Middlewares::AppRequestHandler
+
+    @injected_middlewares = true
+  end
+
+  def self.initialize_log_interceptor!
+    raise "MetaRequest log interceptor initialized twice. Set `require: false' for meta_request in your Gemfile" if @initialized_log_interceptor
+
+    Rails.logger.extend(LogInterceptor) if Rails.logger
+
+    @initialized_log_interceptor = true
+  end
+
+  def self.subscribe_to_notifications!
+    raise "MetaRequest notifications subscribed twice. Set `require: false' for meta_request in your Gemfile" if @subscribed_to_notifications
+
+    AppNotifications.subscribe
+
+    @subscribed_to_notifications = true
+  end
+
   class Railtie < ::Rails::Railtie
-
     initializer 'meta_request.inject_middlewares' do |app|
-      app.middleware.use Middlewares::RequestId unless defined?(ActionDispatch::RequestId)
-      app.middleware.use Middlewares::MetaRequestHandler
-
-      if defined? ActionDispatch::DebugExceptions
-        app.middleware.insert_before ActionDispatch::DebugExceptions, Middlewares::Headers, app.config
-      else
-        app.middleware.use Middlewares::Headers, app.config
-      end
-
-      app.middleware.use Middlewares::AppRequestHandler
+      MetaRequest::inject_middlewares!(app)
     end
 
     initializer 'meta_request.log_interceptor' do
-      Rails.logger.extend(LogInterceptor) if Rails.logger
+      MetaRequest::initialize_log_interceptor!
     end
 
     initializer 'meta_request.subscribe_to_notifications' do
-      AppNotifications.subscribe
+      MetaRequest::subscribe_to_notifications!
     end
 
   end


### PR DESCRIPTION
Inspired by [rack-mini-profiler](https://github.com/MiniProfiler/rack-mini-profiler) I wanted to be able to conditionally enable and disable meta_request through environment variables.

We have a few tools for benchmarking pages and including them all each time we run our development server is not what we want. With my changes you can make a custom initializer and do this:

```ruby
  if ENV['USE_RAILS_PANEL']
    require 'meta_request'

    # Initialize manually since we skipped it in the Gemfile
    MetaRequest::initialize!(Rails.application)
  end
```

The condition can be anything you want really.

I also added some documentation on the matter in de README.

I wasn't sure if you'd even be interested to merge this into the project, so I haven't written the tests yet. Also I think you know better what you want to do with those.

My take is that you can create some sort of group in the rails project under test/functional and then conditionally run using the 'normal' group and the one where meta_request has `require: false` and use an initializer in that case that does what my example above does.

Anyway. Let me know what you think.
