### PR TITLE
Fix missing tab names and hit area in panel

### DIFF
--- a/rails_panel/assets/stylesheets/panel.css
+++ b/rails_panel/assets/stylesheets/panel.css
@@ -292,7 +292,7 @@ table.header th {
   color: #2E2E2E;
   text-shadow: rgba(255, 255, 255, 0.5) 0 1px 0;
   white-space: nowrap;
-  display:block;
+  display: inline-block;
   padding: 0 10px;
   text-align: center;
 }


### PR DESCRIPTION
I recently noticed that after upgrading `meta_request` the tab names and anchor hit area were hidden. This PR modifies the plugin's css to ensure that the names are visible and hit areas are larger. See screenshots below for issue. 

Missing tab names
![image](https://user-images.githubusercontent.com/956570/32067325-d0fc8e50-ba50-11e7-996e-5cb93d22f74a.png)

Missing hit area for clicking tabs
![image](https://user-images.githubusercontent.com/956570/32067355-e9c2d4bc-ba50-11e7-8512-1c1ac90748d9.png)


**After Fix**
![image](https://user-images.githubusercontent.com/956570/32067435-3007fb8c-ba51-11e7-83c2-8272006605d5.png)
