### PR TITLE
Handle missing SQL location

### DIFF
--- a/rails_panel/panel.html
+++ b/rails_panel/panel.html
@@ -158,7 +158,11 @@
                 </thead>
                 <tbody>
                   <tr ng-repeat="sql in activeSqls()" ng-show="showQuery(sql.payload.name)" class="{{sql.payload.name}}">
-                    <td><a href="{{sql.payload.filename | editorify:sql.payload.line}}">{{sql.payload.filename | normalizePath}}:{{sql.payload.line}}</a>
+                    <td>
+                      <span ng-show="sql.payload.filename != undefined && sql.payload.line != undefined">
+                        <a href="{{sql.payload.filename | editorify:sql.payload.line}}">{{sql.payload.filename | normalizePath}}:{{sql.payload.line}}</a>
+                      </span>
+                    </td>
                     <td>{{sql.payload.name}}</td>
                     <td>{{sql.payload.sql}}</td>
                     <td class="duration" data-sort-value="{{-sql.duration}}">{{sql.duration | number:0}} ms</td>


### PR DESCRIPTION
When location is missing (`payload.filename` is undefined) `normalizePath` function throws an error and raw, unprocessed Angular string is rendered.

![screen shot 2018-10-20 at 01 50 05](https://user-images.githubusercontent.com/344698/47258860-07799880-d4a2-11e8-85b2-0fbb908ecb35.png)

Solution copied from https://github.com/gogiel/rails_panel/blob/b5f48b8f4bcde377b5e885b4ef60170efe43f6ac/rails_panel/panel.html#L210-L214