### PR TITLE
Fix empty rails panel in Chrome

### DIFF
--- a/rails_panel/assets/javascripts/background.js
+++ b/rails_panel/assets/javascripts/background.js
@@ -1,6 +1,7 @@
-chrome.extension.onRequest.addListener(function(request, sender, callback) {
-  if (request.action == 'getJSON') {
-    $.getJSON(request.url, callback);
+chrome.runtime.onMessage.addListener(function(message, sender, callback) {
+  if (message.action == 'getJSON') {
+    $.getJSON(message.url, callback);
+    return true;
   }
 });
 

--- a/rails_panel/assets/javascripts/requests.js
+++ b/rails_panel/assets/javascripts/requests.js
@@ -1,6 +1,6 @@
 getJSON = function(url, callback) {
   console.log("sending RPC:" + url);
-  chrome.extension.sendRequest({action:'getJSON',url:url}, callback);
+  chrome.runtime.sendMessage({action:'getJSON',url:url}, callback);
 }
 
 var requests = {


### PR DESCRIPTION
Fixes #142. Needed to return true in onMessage so the getJSON callback is called asynchronously. I also noticed deprecated extension functions were being called, so I switched to the recommended runtime functions instead.