### PR TITLE
No need for pessimistic upper bounds

### DIFF
--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.homepage     = 'https://github.com/dejan/rails_panel/tree/master/meta_request'
   gem.license      = 'MIT'
 
-  gem.add_dependency 'railties', '>= 3.0.0', '< 5.2.0'
-  gem.add_dependency 'rack-contrib', '~> 1.1'
+  gem.add_dependency 'railties', '>= 3.0.0'
+  gem.add_dependency 'rack-contrib', '=> 1.1'
   gem.add_dependency 'callsite', '~> 0.0', '>= 0.0.11'
 
   gem.files        = Dir['README.md', 'lib/**/*.rb']


### PR DESCRIPTION
It basically just ensures that the gem will break when Rails 5.2 comes out, and likely for no good reason.