### PR TITLE
Don't deselect my transaction when a new request comes in

### DIFF
--- a/rails_panel/assets/javascripts/panel.js
+++ b/rails_panel/assets/javascripts/panel.js
@@ -27,7 +27,7 @@ var panel = {
   },
 
   mockDataTimer: function(scope) {
-    var timeout = setTimeout(
+    setTimeout(
       function() { panel.addMockData(scope) },
       5000
     );

--- a/rails_panel/assets/javascripts/panel.js
+++ b/rails_panel/assets/javascripts/panel.js
@@ -1,3 +1,4 @@
+var mockDataIndex = 0;
 var panel = {
 
   clearData: function(scope) {
@@ -7,19 +8,29 @@ var panel = {
   },
 
   addData: function(requestId, scope, data) {
-    data.each(function(n) { 
+    data.each(function(n) {
       scope.$apply(function() {
         scope.parseNotification(requestId, n);
-      }); 
+      });
     });
   },
 
   addMockData: function(scope) {
-    this.addData('1', scope, mockTransactions1());
-    this.addData('2', scope, mockTransactions2());
-    this.addData('3', scope, mockTransactions3());
-    this.addData('4', scope, mockTransactions4());
+    this.addData(mockDataIndex + 1, scope, mockTransactions1());
+    this.addData(mockDataIndex + 2, scope, mockTransactions2());
+    this.addData(mockDataIndex + 3, scope, mockTransactions3());
+    this.addData(mockDataIndex + 4, scope, mockTransactions4());
+    mockDataIndex = mockDataIndex + 4;
+
+    // Simulate new requests coming in every couple of seconds
+    panel.mockDataTimer(scope);
+  },
+
+  mockDataTimer: function(scope) {
+    var timeout = setTimeout(
+      function() { panel.addMockData(scope) },
+      5000
+    );
   }
-  
 };
 

--- a/rails_panel/assets/javascripts/transactions.js
+++ b/rails_panel/assets/javascripts/transactions.js
@@ -129,7 +129,10 @@ function TransactionsCtrl($scope) {
         $scope.pushToMap($scope.paramsMap, key, {name:n, value:data.payload.params[n]});
       });
       $scope.transactionKeys.push(key);
-      $scope.setActive(key);
+
+      if ($scope.activeKey === null) {
+        $scope.setActive(key);
+      }
       break;
     case "process_action.action_controller.exception":
       $scope.pushToMap($scope.exceptionCallsMap, key, data);

--- a/rails_panel/manifest.json
+++ b/rails_panel/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RailsPanel",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "manifest_version": 2,
   "description": "Devtools panel for Rails development",
   "devtools_page": "devtools.html",


### PR DESCRIPTION
## Summary

- Don't change $scope.activeKey when it's already set
- Update mock data every 5 seconds to simulate what's going on in many applications these days
- Bump version to 0.3.4

## Many words

When debugging an application where transactions keep coming in, RailsPanel would keep selecting the newest transaction. 

This is a bit annoying (understatement) when you're looking at a specific transaction to see what's going on. I fixed that by only automatically selecting a transaction when there is no transaction selected. I also added some code to the mock data function to simulate new transactions coming in every couple of seconds.

To test, open panel.html in Chrome and see the mock requests coming in, and the new requests not being selected (as they previously were).