### PR TITLE
Add missing attr_writers to config

### DIFF
--- a/meta_request/.gitignore
+++ b/meta_request/.gitignore
@@ -16,3 +16,4 @@ test/reports
 test/tmp
 test/version_tmp
 tmp
+log/

--- a/meta_request/lib/meta_request/config.rb
+++ b/meta_request/lib/meta_request/config.rb
@@ -1,5 +1,7 @@
 module MetaRequest
   class Config
+    attr_writer :logger, :storage_pool_size
+
     # logger used for reporting gem's fatal errors
     def logger
       @logger ||= Logger.new(File.join(Rails.root, 'log', 'meta_request.log'))

--- a/meta_request/test/unit/meta_request/config_test.rb
+++ b/meta_request/test/unit/meta_request/config_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+describe MetaRequest::Config do
+  let(:config) { MetaRequest::Config.new }
+
+  describe 'logger' do
+    it 'is present by default' do
+      FileUtils.mkdir_p File.join(Rails.root, 'log')
+      assert_kind_of Logger, config.logger
+    end
+
+    it 'can be customized' do
+      new_logger = Logger.new STDOUT
+      config.logger = new_logger
+      assert_equal new_logger, config.logger
+    end
+  end
+
+  describe 'storage_pool_size' do
+    it 'is 20 by default' do
+      assert_equal 20, config.storage_pool_size
+    end
+
+    it "can be customized" do
+      config.storage_pool_size = 50
+      assert_equal 50, config.storage_pool_size
+    end
+  end
+end


### PR DESCRIPTION
attr_writers were accidentally removed by me at https://github.com/dejan/rails_panel/commit/1f1a4d309596d39bb81213361458d99f5740505b#diff-4ade6c3c1b1d1315271db7ac73495c5e

This PR reverts it and adds a test.