### PR TITLE
Introduce source_path configuration

### DIFF
--- a/meta_request/README.md
+++ b/meta_request/README.md
@@ -35,6 +35,18 @@ end
 
 List of available attributes and defaults can be found in [lib/meta_request/config.rb](lib/meta_request/config.rb).
 
+## Docker
+
+Apps runing in Docker container will have filepaths of the container so links to editor would not work. To fix this, you need to propagate working directory through enviroment variable `SOURCE_PATH`. With docker-compose it can be done like this:
+
+```yaml
+services:
+  app:
+    environment:
+      - SOURCE_PATH=$PWD
+    # ...
+```
+
 ## Development
 
 Run all tests:

--- a/meta_request/lib/meta_request/config.rb
+++ b/meta_request/lib/meta_request/config.rb
@@ -1,6 +1,6 @@
 module MetaRequest
   class Config
-    attr_writer :logger, :storage_pool_size
+    attr_writer :logger, :storage_pool_size, :source_path
 
     # logger used for reporting gem's fatal errors
     def logger
@@ -11,6 +11,10 @@ module MetaRequest
     # Increase when using an application loading many simultaneous requests.
     def storage_pool_size
       @storage_pool_size ||= 20
+    end
+
+    def source_path
+      @source_path ||= ENV['SOURCE_PATH'] || Rails.root.to_s
     end
   end
 end

--- a/meta_request/lib/meta_request/log_interceptor.rb
+++ b/meta_request/lib/meta_request/log_interceptor.rb
@@ -31,12 +31,11 @@ module MetaRequest
       super
     end
 
-
     private
     def push_event(level, message)
-      dev_callsite = AppRequest.current && Utils.dev_callsite(caller[1])
-      if dev_callsite
-        payload = {:message => message, :level => level, :line => dev_callsite.line, :filename => dev_callsite.filename, :method => dev_callsite.method}
+      callsite = AppRequest.current && Utils.dev_callsite(caller.drop(1))
+      if callsite
+        payload = callsite.merge(message: message, level: level)
         AppRequest.current.events << Event.new('meta_request.log', 0, 0, 0, payload)
       end
     rescue Exception => e

--- a/meta_request/lib/meta_request/utils.rb
+++ b/meta_request/lib/meta_request/utils.rb
@@ -1,13 +1,25 @@
-require 'callsite'
-
 module MetaRequest
   module Utils
     extend self
 
-    # @return [Callsite::Line, nil]
     def dev_callsite(caller)
-      app_line = Array(caller).detect { |c| c.start_with? MetaRequest.rails_root }
-      Callsite.parse(app_line) if app_line
+      app_line = caller.detect { |c| c.start_with? MetaRequest.rails_root }
+      return nil unless app_line
+
+      _, filename, _, line, _, method = app_line.split(/^(.*?)(:(\d+))(:in `(.*)')?$/)
+
+      {
+        filename: sub_source_path(filename),
+        line: line.to_i,
+        method: method
+      }
+    end
+
+    def sub_source_path(path)
+      rails_root = MetaRequest.rails_root
+      source_path = MetaRequest.config.source_path
+      return path if rails_root == source_path
+      path.sub(rails_root, source_path)
     end
   end
 end

--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'railties', '>= 3.0.0', '< 7'
   gem.add_dependency 'rack-contrib', '>= 1.1', '< 3'
-  gem.add_dependency 'callsite', '~> 0.0', '>= 0.0.11'
 
   gem.files        = Dir['README.md', 'lib/**/*.rb']
 end

--- a/meta_request/test/unit/meta_request/utils_test.rb
+++ b/meta_request/test/unit/meta_request/utils_test.rb
@@ -2,35 +2,45 @@ require 'test_helper'
 
 describe MetaRequest::Utils do
   describe '.dev_callsite' do
-    it 'returns line parsed with Callsite if rails root is found in multi-line trace' do
+    it 'returns first call site from the app iself' do
+      filename = File.join(MetaRequest.rails_root, "test_file.rb") 
+      line = 87
+      method = 'app_func'
+
       stacktrace = [
         "/gem/gem_file.rb:1:in `func'`",
-        "#{File.join(MetaRequest.rails_root, "test_file.rb")}:87:in `app_func'",
+        "#{filename}:#{line}:in `#{method}'",
         "/gem/gem_file.rb:1:in `func2'`",
       ]
-      expected_callsite_line = Callsite::Line.new("#{Rails.root}/test_file.rb", 87, 'app_func')
-      assert_equal expected_callsite_line, MetaRequest::Utils.dev_callsite(stacktrace)
+
+      expected = { filename: filename, line: line, method: method }
+      assert_equal expected, MetaRequest::Utils.dev_callsite(stacktrace)
     end
 
-    it "returns nil if multi-line trace doesn't match app root" do
+    it 'returns nil if the stacktrace contains only call sites outside of the app' do
       stacktrace = [
         "/gem/gem_file.rb:1:in `func'`",
-        "/prefix/#{File.join(MetaRequest.rails_root, "test_file.rb")}:87:in `app_func'",
         "/gem/gem_file.rb:1:in `func2'`",
       ]
+
       assert_nil MetaRequest::Utils.dev_callsite(stacktrace)
     end
 
-    it 'returns line parsed with Callsite if rails root is found in a single line trace' do
-      stacktrace = "#{File.join(MetaRequest.rails_root, "test_file.rb")}:87:in `app_func'"
-      expected_callsite_line = Callsite::Line.new("#{Rails.root}/test_file.rb", 87, "app_func")
-      assert_equal expected_callsite_line, MetaRequest::Utils.dev_callsite(stacktrace)
-    end
+    it 'replaces filename with the proovided source path configuration' do
+      MetaRequest.config.source_path = '/Users/foo/bar'
 
-    it "returns nil if single-line trace doesn't match app root" do
-      stacktrace =  "/gem/gem_file.rb:1:in `func'`"
+      filename = File.join(MetaRequest.rails_root, "test_file.rb")
+      line = 87
+      method = 'app_func'
+      stacktrace = [
+        "#{filename}:#{line}:in `#{method}'"
+      ]
 
-      assert_nil MetaRequest::Utils.dev_callsite(stacktrace)
+      expected = { filename: '/Users/foo/bar/test_file.rb', line: line, method: method }
+      assert_equal expected, MetaRequest::Utils.dev_callsite(stacktrace)
+
+      # revert configuration
+      MetaRequest.config.source_path = MetaRequest.rails_root
     end
   end
 end


### PR DESCRIPTION
The change addresses the problem described in: https://github.com/dejan/rails_panel/issues/128

The new config option is added that allows override of the source path (by default it's Rails.root). Using this it's possible to run the app in the Docker container and still get the correct file paths (from the host system):

```yaml
services:
  app:
    environment:
      - SOURCE_PATH=$PWD
```
