### PR TITLE
Firefox support - minor style fixes

### DIFF
--- a/rails_panel/assets/stylesheets/panel.css
+++ b/rails_panel/assets/stylesheets/panel.css
@@ -10,6 +10,9 @@ ul {
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
   -webkit-margin-start: -30px;
+  -moz-margin-start: -30px;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .data-grid {

--- a/rails_panel/manifest.json
+++ b/rails_panel/manifest.json
@@ -4,7 +4,9 @@
   "manifest_version": 2,
   "description": "Devtools panel for Rails development",
   "devtools_page": "devtools.html",
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html"
+  },
   "background": {
     "scripts": [
       "vendor/assets/javascripts/jquery-1.8.3.min.js",

--- a/rails_panel/options.html
+++ b/rails_panel/options.html
@@ -8,7 +8,7 @@
     <script src="assets/javascripts/options.js"></script>
   </head>
   <body>
-    <div class="container">
+    <div>
       <h2>
         <img src="assets/images/Rails_Logo_48x48.png"/>
         RailsPanel


### PR DESCRIPTION
Refs https://github.com/dejan/rails_panel/issues/141

I did some minor changes to make it fully functional on Firefox.

1. Updated manifest to match newest standard as it was showing an error:
<img width="685" alt="before-error" src="https://user-images.githubusercontent.com/344698/67624071-b165d080-f82c-11e9-8889-6c16ed41ceab.png">

2. Updated Devtools tabs CSS
Before:
<img width="1292" alt="before-devtools" src="https://user-images.githubusercontent.com/344698/67624080-c3477380-f82c-11e9-82a3-bd947f8ab1ce.png">

After:
<img width="1138" alt="after-devtools" src="https://user-images.githubusercontent.com/344698/67624084-c8a4be00-f82c-11e9-8f1e-e9de8d8b85a3.png">

3. Updated Options page to make it more responsive.
Before it was wider than the viewport:

![before-options](https://user-images.githubusercontent.com/344698/67624090-d65a4380-f82c-11e9-8177-220c1be9a422.png)

After:
![after-options](https://user-images.githubusercontent.com/344698/67624096-e3773280-f82c-11e9-92eb-bdd8f2a0593b.png)
