### PR TITLE
Test Rails 4.2 instead of Rails 4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - setup_remote_docker
       - run: docker-compose run --rm test-unit
 
-  test_rails_4_1:
+  test_rails_4_2:
     docker:
       - image: circleci/buildpack-deps
     working_directory: ~/project/meta_request
@@ -28,7 +28,7 @@ jobs:
       - checkout:
           path: ~/project
       - setup_remote_docker
-      - run: docker-compose run --rm test-rails-4.1
+      - run: docker-compose run --rm test-rails-4.2
 
   test_rails_5_0:
     docker:
@@ -76,7 +76,7 @@ workflows:
     jobs:
       - rubocop
       - unit_tests
-      - test_rails_4_1
+      - test_rails_4_2
       - test_rails_5_0
       - test_rails_5_1
       - test_rails_5_2

--- a/meta_request/Dockerfile-rails-4.2
+++ b/meta_request/Dockerfile-rails-4.2
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.6-alpine
 
 RUN apk add --update --no-cache \
      build-base curl-dev git sqlite-dev \
@@ -7,7 +7,7 @@ RUN apk add --update --no-cache \
 RUN mkdir /app /gem
 WORKDIR /app
 
-RUN gem install rails -v 4.1.16
+RUN gem install rails -v 4.2.11
 RUN rails new . --skip-spring
 
 RUN bundle remove sqlite3

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -5,10 +5,10 @@ services:
     command: bundle exec rubocop
   test-unit:
     build: .
-  test-rails-4.1:
+  test-rails-4.2:
     build:
       context: .
-      dockerfile: Dockerfile-rails-4.1
+      dockerfile: Dockerfile-rails-4.2
   test-rails-5.0:
     build:
       context: .


### PR DESCRIPTION
Rails 4.1 (from 2014-2016) doesn't work correctly with new Ruby versions and new gems.

It's sane to drop tests for it and test using more modern Rails 4.2 which latest version was released this year.