### PR TITLE
Ignored paths inside application

### DIFF
--- a/meta_request/lib/meta_request/config.rb
+++ b/meta_request/lib/meta_request/config.rb
@@ -18,5 +18,17 @@ module MetaRequest
     def source_path
       @source_path ||= ENV['SOURCE_PATH'] || Rails.root.to_s
     end
+
+    # List of relative paths inside Rails app. Used in Location calculation.
+    def ignored_paths
+      self.ignored_paths = %w[bin vendor] unless @ignored_paths
+      @ignored_paths
+    end
+
+    def ignored_paths=(paths)
+      @ignored_paths = paths.map do |path|
+        Rails.root.join(path).to_s.freeze
+      end.freeze
+    end
   end
 end

--- a/meta_request/lib/meta_request/utils.rb
+++ b/meta_request/lib/meta_request/utils.rb
@@ -5,7 +5,7 @@ module MetaRequest
     module_function
 
     def dev_callsite(caller)
-      app_line = caller.detect { |c| c.start_with? MetaRequest.rails_root }
+      app_line = caller.detect { |c| valid_application_path? c }
       return nil unless app_line
 
       _, filename, _, line, _, method = app_line.split(/^(.*?)(:(\d+))(:in `(.*)')?$/)
@@ -23,6 +23,16 @@ module MetaRequest
       return path if rails_root == source_path
 
       path.sub(rails_root, source_path)
+    end
+
+    def valid_application_path?(path)
+      path.start_with?(MetaRequest.rails_root) && !ignored_path?(path)
+    end
+
+    def ignored_path?(path)
+      MetaRequest.config.ignored_paths.any? do |ignored_path|
+        path.start_with?(ignored_path.to_s)
+      end
     end
   end
 end

--- a/meta_request/spec/meta_request/utils_spec.rb
+++ b/meta_request/spec/meta_request/utils_spec.rb
@@ -45,4 +45,29 @@ RSpec.describe MetaRequest::Utils, '.dev_callsite' do
     # revert configuration
     MetaRequest.config.source_path = MetaRequest.rails_root
   end
+
+  it 'ignores ignored paths' do
+    filename = File.join(MetaRequest.rails_root, 'test_file.rb')
+    line = 87
+    method = 'app_func'
+    vendor_filename = File.join(MetaRequest.rails_root, 'vendor', 'test_file.rb')
+
+    stacktrace = [
+      "/gem/gem_file.rb:1:in `func'`",
+      "#{vendor_filename}:#{line}:in `#{method}'",
+      "#{filename}:#{line}:in `#{method}'",
+      "#{vendor_filename}:#{line}:in `#{method}'",
+      "/gem/gem_file.rb:1:in `func2'`"
+    ]
+
+    expect(MetaRequest::Utils.dev_callsite(stacktrace)).to eq(
+      filename: filename, line: line, method: method
+    )
+
+    stacktrace = [
+      "#{vendor_filename}:#{line}:in `#{method}'"
+    ]
+
+    expect(MetaRequest::Utils.dev_callsite(stacktrace)).to be(nil)
+  end
 end

--- a/meta_request/spec/spec_helper.rb
+++ b/meta_request/spec/spec_helper.rb
@@ -14,7 +14,7 @@ end
 
 module Rails
   def self.root
-    Dir.pwd
+    Pathname(Dir.pwd)
   end
 end
 


### PR DESCRIPTION
It's often a case that gems are bundled inside application directory in `vendor/`. Fixes https://github.com/dejan/rails_panel/issues/171

Additionally I added `bin/` path to ignore `bin/rails`.
