### PR TITLE
Relative path calculation on the backend

### DIFF
--- a/meta_request/lib/meta_request/app_notifications.rb
+++ b/meta_request/lib/meta_request/app_notifications.rb
@@ -49,7 +49,9 @@ module MetaRequest
 
     VIEW_BLOCK = proc { |*args|
       name, start, ending, transaction_id, payload = args
-      payload[:identifier] = MetaRequest::Utils.sub_source_path(payload[:identifier])
+      identifier = payload[:identifier]
+      payload[:identifier] = MetaRequest::Utils.sub_source_path(identifier)
+      payload[:relative_identifier] = MetaRequest::Utils.relative_path(identifier)
 
       Event.new(name, start, ending, transaction_id, payload)
     }

--- a/meta_request/lib/meta_request/utils.rb
+++ b/meta_request/lib/meta_request/utils.rb
@@ -12,6 +12,7 @@ module MetaRequest
 
       {
         filename: sub_source_path(filename),
+        relative_filename: relative_path(filename),
         line: line.to_i,
         method: method
       }
@@ -23,6 +24,10 @@ module MetaRequest
       return path if rails_root == source_path
 
       path.sub(rails_root, source_path)
+    end
+
+    def relative_path(path)
+      path.sub(MetaRequest.rails_root, '').sub(%r{\A/}, '')
     end
   end
 end

--- a/meta_request/lib/meta_request/utils.rb
+++ b/meta_request/lib/meta_request/utils.rb
@@ -23,11 +23,11 @@ module MetaRequest
       source_path = MetaRequest.config.source_path
       return path if rails_root == source_path
 
-      path.sub(rails_root, source_path)
+      path.sub(%r{\A#{rails_root}}, source_path)
     end
 
     def relative_path(path)
-      path.sub(MetaRequest.rails_root, '').sub(%r{\A/}, '')
+      path.sub(%r{\A#{MetaRequest.rails_root}/?}, '')
     end
   end
 end

--- a/meta_request/spec/meta_request/utils_spec.rb
+++ b/meta_request/spec/meta_request/utils_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe MetaRequest::Utils, '.dev_callsite' do
     ]
 
     expect(MetaRequest::Utils.dev_callsite(stacktrace)).to eq(
-      filename: filename, line: line, method: method
+      filename: filename, relative_filename: 'test_file.rb',
+      line: line, method: method
     )
   end
 
@@ -39,7 +40,8 @@ RSpec.describe MetaRequest::Utils, '.dev_callsite' do
     ]
 
     expect(MetaRequest::Utils.dev_callsite(stacktrace)).to eq(
-      filename: '/Users/foo/bar/test_file.rb', line: line, method: method
+      filename: '/Users/foo/bar/test_file.rb',
+      relative_filename: 'test_file.rb', line: line, method: method
     )
 
     # revert configuration

--- a/rails_panel/panel.html
+++ b/rails_panel/panel.html
@@ -160,7 +160,10 @@
                   <tr ng-repeat="sql in activeSqls()" ng-show="showQuery(sql.payload.name)" class="{{sql.payload.name}}">
                     <td>
                       <span ng-show="sql.payload.filename != undefined && sql.payload.line != undefined">
-                        <a href="{{sql.payload.filename | editorify:sql.payload.line}}">{{sql.payload.filename | normalizePath}}:{{sql.payload.line}}</a>
+                        <a href="{{sql.payload.filename | editorify:sql.payload.line}}">
+                          <span ng-show="!sql.payload.relative_filename">{{ sql.payload.filename | normalizePath}}:{{sql.payload.line}}</span>
+                          <span ng-show="sql.payload.relative_filename">{{ sql.payload.relative_filename}}:{{sql.payload.line}}</span>
+                        </a>
                       </span>
                     </td>
                     <td>{{sql.payload.name}}</td>
@@ -185,7 +188,10 @@
                 <tbody>
                   <tr ng-repeat="view in activeViews()">
                     <td>
-                      <a href="{{view.payload.identifier | editorify:1}}">{{view.payload.identifier | normalizePath}}</a>
+                      <a href="{{view.payload.identifier | editorify:1}}">
+                        <span ng-show="!view.payload.relative_identifier">{{view.payload.identifier | normalizePath}}</span>
+                        <span ng-show="view.payload.relative_identifier">{{view.payload.relative_identifier}}</span>
+                      </a>
                       <span ng-show="view.payload.layout">within {{view.payload.layout}}</span>
                     </td>
                     <td class="duration" data-sort-value="{{-view.duration}}">{{view.duration | number:0}} ms</td>
@@ -209,7 +215,10 @@
                   <tr ng-repeat="cache in activeCaches()" class="{{cache.payload.name}}">
                     <td>
                       <span ng-show="cache.payload.filename != undefined && cache.payload.line != undefined">
-                        <a href="{{cache.payload.filename | editorify:cache.payload.line }}">{{cache.payload.filename | normalizePath}}:{{cache.payload.line}}</a>
+                        <a href="{{cache.payload.filename | editorify:cache.payload.line }}">
+                          <span ng-show="!cache.payload.relative_filename">{{cache.payload.filename | normalizePath}}:{{cache.payload.line}}</span>
+                          <span ng-show="cache.payload.relative_filename">{{cache.payload.relative_filename}}:{{cache.payload.line}}</span>
+                        </a>
                       </span>
                     </td>
                     <td>{{cache.payload.type}}</td>
@@ -231,7 +240,10 @@
                 </thead>
                 <tbody>
                   <tr ng-repeat="log in activeLog()">
-                    <td><a href="{{log.payload.filename | editorify:log.payload.line}}">{{log.payload.filename | normalizePath}}:{{log.payload.line}}</a></td>
+                    <td><a href="{{log.payload.filename | editorify:log.payload.line}}">
+                      <span ng-show="!log.payload.relative_filename">{{log.payload.filename | normalizePath}}:{{log.payload.line}}</span>
+                      <span ng-show="log.payload.relative_filename">{{log.payload.relative_filename}}:{{log.payload.line}}</span>
+                    </a></td>
                     <td ng-bind-html-unsafe="log.payload.message | toString | sanitize | ansi2html"></td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Related to https://github.com/dejan/rails_panel/issues/171

It aims to replace `normalizePath` filter which:
* doesn't work well if path includes `/app/`
* doesn't support files in other directories, like `lib/`

https://github.com/dejan/rails_panel/blob/4204111affa05fec6793a77e37072bd4a079f251/rails_panel/assets/javascripts/filters.js#L34-L38

Frontend changes are backward compatible.