### PR TITLE
Do not attempt to convert ActionDispatch::Request/Response to JSON

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,16 @@ jobs:
       - setup_remote_docker
       - run: docker-compose run --rm test-rails-6.0
 
+  test_rails_6_1:
+    docker:
+      - image: circleci/buildpack-deps
+    working_directory: ~/project/meta_request
+    steps:
+      - checkout:
+          path: ~/project
+      - setup_remote_docker
+      - run: docker-compose run --rm test-rails-6.1
+
 workflows:
   version: 2
   test_all:
@@ -81,3 +91,4 @@ workflows:
       - test_rails_5_1
       - test_rails_5_2
       - test_rails_6_0
+      - test_rails_6_1

--- a/meta_request/Dockerfile-rails-6.1
+++ b/meta_request/Dockerfile-rails-6.1
@@ -1,0 +1,31 @@
+FROM ruby:2.6-alpine
+
+RUN apk add --update --no-cache \
+     build-base curl-dev git sqlite-dev \
+     yaml-dev zlib-dev nodejs yarn tzdata
+
+RUN mkdir /app /gem
+WORKDIR /app
+
+RUN gem install rails -v 6.1.0
+RUN rails new .
+
+RUN bundle install
+
+COPY . /gem
+
+RUN gem build /gem/meta_request.gemspec
+RUN gem install /gem/meta_request-*.gem
+RUN bundle add meta_request
+RUN bundle install --local
+
+COPY res/routes.rb /app/config/
+COPY res/dummy_controller.rb /app/app/controllers/
+COPY res/dummy /app/app/views/dummy
+COPY res/meta_request_test.rb /app/test/integration/
+
+RUN bundle exec rails db:migrate
+
+ENV PARALLEL_WORKERS 1
+
+CMD ["bin/rake"]

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -25,3 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-rails-6.0
+  test-rails-6.1:
+    build:
+      context: .
+      dockerfile: Dockerfile-rails-6.1

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -40,7 +40,7 @@ module MetaRequest
       transform_hash(payload, deep: true) do |hash, key, value|
         if value.class.to_s == 'ActionDispatch::Http::Headers'
           value = value.to_h.select { |k, _| k.upcase == k }
-        elsif defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+        elsif not_encodable?(value)
           value = NOT_JSON_ENCODABLE
         end
 
@@ -52,6 +52,11 @@ module MetaRequest
         end
         hash[key] = new_value
       end.with_indifferent_access
+    end
+
+    def not_encodable?(value)
+      (defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)) ||
+        (defined?(ActionDispatch) && (value.is_a?(ActionDispatch::Request)) || value.is_a?(ActionDispatch::Response))
     end
 
     # https://gist.github.com/dbenhur/1070399

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -56,7 +56,8 @@ module MetaRequest
 
     def not_encodable?(value)
       (defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)) ||
-        (defined?(ActionDispatch) && (value.is_a?(ActionDispatch::Request)) || value.is_a?(ActionDispatch::Response))
+        (defined?(ActionDispatch) &&
+          (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response)))
     end
 
     # https://gist.github.com/dbenhur/1070399


### PR DESCRIPTION
Since Rails 6.1, the payload of action dispatch can't be converted.

It's not guaranteed `to_json` conversion, and `SystemStackError` got to happen.
To avoid this, fixed to ignore `ActionDispatch::Request/ActionDispatch::Response` to JSON.

and added test for rails 6.1