### PR TITLE
fix(docs): corrects common typos in project documentation

### DIFF
--- a/meta_request/README.md
+++ b/meta_request/README.md
@@ -37,7 +37,7 @@ List of available attributes and defaults can be found in [lib/meta_request/conf
 
 ## Docker
 
-Apps runing in Docker container will have filepaths of the container so links to editor would not work. To fix this, you need to propagate working directory through enviroment variable `SOURCE_PATH`. With docker-compose it can be done like this:
+Apps running in Docker container will have filepaths of the container so links to editor would not work. To fix this, you need to propagate working directory through environment variable `SOURCE_PATH`. With docker-compose it can be done like this:
 
 ```yaml
 services:


### PR DESCRIPTION
Scope of changes is restricted to docs only.