### PR TITLE
Add support to Mongoid

### DIFF
--- a/meta_request/lib/meta_request.rb
+++ b/meta_request/lib/meta_request.rb
@@ -7,6 +7,7 @@ module MetaRequest
   autoload :AppRequest,       'meta_request/app_request'
   autoload :Storage,          'meta_request/storage'
   autoload :Middlewares,      'meta_request/middlewares'
+  autoload :Subscribers,      'meta_request/subscribers'
   autoload :LogInterceptor,   'meta_request/log_interceptor'
   autoload :AppNotifications, 'meta_request/app_notifications'
   autoload :Utils,            'meta_request/utils'

--- a/meta_request/lib/meta_request/app_notifications.rb
+++ b/meta_request/lib/meta_request/app_notifications.rb
@@ -57,6 +57,10 @@ module MetaRequest
     # Subscribe to all events relevant to RailsPanel
     #
     def self.subscribe
+      if Mongo and Mongo::Monitoring and Mongo::Monitoring::Global
+        Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, MetaRequest::Subscribers::MongoCommandSubscriber.new)
+      end
+
       new
         .subscribe('meta_request.log')
         .subscribe('sql.active_record', &SQL_BLOCK)

--- a/meta_request/lib/meta_request/subscribers.rb
+++ b/meta_request/lib/meta_request/subscribers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module MetaRequest
+  module Subscribers
+    autoload :MongoCommandSubscriber, 'meta_request/subscribers/mongo_command_subscriber'
+  end
+end

--- a/meta_request/lib/meta_request/subscribers/mongo_command_subscriber.rb
+++ b/meta_request/lib/meta_request/subscribers/mongo_command_subscriber.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MetaRequest
+  module Subscribers
+    class MongoCommandSubscriber
+      def started(event)
+        # puts "Started #{event.command_name}: #{event.command}"
+      end
+
+      def failed(event)
+        # puts "Failed #{event.command_name}: #{event.message}"
+      end
+
+      def succeeded(event)
+        start_time = Time.now - event.duration
+        end_time = Time.now
+        transaction_id = event.request_id
+        command = event.started_event.command.to_json
+        payload = { name: event.command_name, sql: command }
+        ActiveSupport::Notifications.publish('sql.active_record', start_time, end_time, transaction_id, payload)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Actually it'll forward Mongoid events as if they were ActiveRecord events, showing up in the `Active Record` tab of the Rails Panel extension.

I'm using `Mongo::Monitoring::Global.subscribe` here because Mongoid doesn't emit events that could be listen by `ActiveSupport::Notifications.subscribe`.