### PR TITLE
Add Rails 7.1 Support

### DIFF
--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.license      = 'MIT'
 
   gem.add_dependency 'rack-contrib', '>= 1.1', '< 3'
-  gem.add_dependency 'railties', '>= 3.0.0', '< 7.1'
+  gem.add_dependency 'railties', '>= 3.0.0', '<= 7.1'
   gem.add_development_dependency 'rspec', '~> 3.8.0'
   gem.add_development_dependency 'rubocop', '~> 0.74.0'
 


### PR DESCRIPTION
The railties dependency was blocking compatibility with a new version,
after allowing it should be fine.

Fixes https://github.com/dejan/rails_panel/issues/180
