### PR TITLE
chore: mark as compatible with rails 7.1

### DIFF
--- a/meta_request/Dockerfile-rails-7.1
+++ b/meta_request/Dockerfile-rails-7.1
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ruby:3.2
 
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
@@ -18,7 +18,7 @@ RUN mkdir /app /gem
 WORKDIR /app
 
 RUN gem update --system && \
-    gem install rails -v 7.0.4 && |
+    gem install rails -v 7.1.1 && |
     rails new .
 
 COPY . /gem

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -21,3 +21,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-rails-7.0
+  test-rails-7.1:
+    build:
+      context: .
+      dockerfile: Dockerfile-rails-7.1

--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.license      = 'MIT'
 
   gem.add_dependency 'rack-contrib', '>= 1.1', '< 3'
-  gem.add_dependency 'railties', '>= 3.0.0', '< 7.1'
+  gem.add_dependency 'railties', '>= 3.0.0', '< 7.2'
   gem.add_development_dependency 'rspec', '~> 3.8.0'
   gem.add_development_dependency 'rubocop', '~> 0.74.0'
 


### PR DESCRIPTION
Tested locally and it seems to work with no other changes

I had to convert the Dockerfile to use Debian-based images instead of Alpine because current versions of `nokogiri` include binaries in them that link against glibc and fail to run when ruby is linked against musl libc.