### PR TITLE
Rails 7.1 Incompatibility: Exclude Payload Locals

### DIFF
--- a/meta_request/Dockerfile-rails-7.1
+++ b/meta_request/Dockerfile-rails-7.1
@@ -1,0 +1,36 @@
+FROM ruby:3.0-alpine
+
+RUN apk add --update --no-cache \
+        build-base \
+        curl-dev \
+        git \
+        nodejs \
+        shared-mime-info \
+        sqlite-dev \
+        tzdata \
+        yaml-dev \
+        yarn \
+        zlib-dev
+
+RUN mkdir /app /gem
+WORKDIR /app
+
+RUN gem update --system 3.5.7
+RUN bundle config force_ruby_platform true
+RUN gem install rails -v 7.1.3.2
+RUN rails new .
+
+COPY . /gem
+RUN bundle add meta_request --path /gem
+RUN bundle install
+
+COPY res/routes.rb /app/config/
+COPY res/dummy_controller.rb /app/app/controllers/
+COPY res/dummy /app/app/views/dummy
+COPY res/meta_request_test.rb /app/test/integration/
+
+RUN bundle exec rails db:migrate
+
+ENV PARALLEL_WORKERS 1
+
+CMD ["bin/rake"]

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -65,9 +65,11 @@ module MetaRequest
     end
 
     def not_encodable?(value)
-      (defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)) ||
-        (defined?(ActionDispatch) &&
-          (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response)))
+      return true if defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+      return true if defined?(ActionDispatch) && (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response))
+      return true if defined?(ActionView) && value.is_a?(ActionView::Helpers::FormBuilder)
+
+      false
     end
 
     # https://gist.github.com/dbenhur/1070399

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -61,7 +61,7 @@ module MetaRequest
         payload[:key] = ActiveSupport::Cache::Store.new.send(:normalize_key, payload[:key])
       end
 
-      payload
+      payload.except(:locals)
     end
 
     def not_encodable?(value)

--- a/meta_request/meta_request.gemspec
+++ b/meta_request/meta_request.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name         = 'meta_request'
-  gem.version      = '0.8.2'
+  gem.version      = '0.8.3'
 
   gem.summary      = 'Request your Rails request'
   gem.description  = 'Supporting gem for Rails Panel (Google Chrome extension for Rails development)'


### PR DESCRIPTION
Due to Rails monkey patching the Object#to_json method, it is possible for an unassuming object to call the method and trigger a <SystemStackError: stack level too deep> error.

https://github.com/rails/rails/blob/v7.1.3.2/activesupport/lib/active_support/core_ext/object/json.rb#L63

We discovered a case where this was caused by an instance of ActionView::Helpers::FormBuilder. We extended MetaRequest::Event#not_encodable? to exclude this class and prevent the recursion.