### PR TITLE
Improve Rails 7.2 compatibility

### DIFF
--- a/meta_request/Dockerfile-rails-7.2
+++ b/meta_request/Dockerfile-rails-7.2
@@ -1,0 +1,36 @@
+FROM ruby:3.1-alpine
+
+RUN apk add --update --no-cache \
+        build-base \
+        curl-dev \
+        git \
+        nodejs \
+        shared-mime-info \
+        sqlite-dev \
+        tzdata \
+        yaml-dev \
+        yarn \
+        zlib-dev
+
+RUN mkdir /app /gem
+WORKDIR /app
+
+RUN gem update --system 3.5.7
+RUN bundle config force_ruby_platform true
+RUN gem install rails -v 7.2.1.1
+RUN rails new .
+
+COPY . /gem
+RUN bundle add meta_request --path /gem
+RUN bundle install
+
+COPY res/routes.rb /app/config/
+COPY res/dummy_controller.rb /app/app/controllers/
+COPY res/dummy /app/app/views/dummy
+COPY res/meta_request_test.rb /app/test/integration/
+
+RUN bundle exec rails db:migrate
+
+ENV PARALLEL_WORKERS 1
+
+CMD ["bin/rake"]

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -21,3 +21,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-rails-7.0
+  test-rails-7.1:
+    build:
+      context: .
+      dockerfile: Dockerfile-rails-7.1

--- a/meta_request/docker-compose.yml
+++ b/meta_request/docker-compose.yml
@@ -25,3 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-rails-7.1
+  test-rails-7.2:
+    build:
+      context: .
+      dockerfile: Dockerfile-rails-7.2

--- a/meta_request/lib/meta_request/event.rb
+++ b/meta_request/lib/meta_request/event.rb
@@ -66,6 +66,7 @@ module MetaRequest
 
     def not_encodable?(value)
       return true if defined?(ActiveRecord) && value.is_a?(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+      return true if defined?(ActiveRecord) && defined?(ActiveRecord::Transaction) && value.is_a?(ActiveRecord::Transaction)
       return true if defined?(ActionDispatch) && (value.is_a?(ActionDispatch::Request) || value.is_a?(ActionDispatch::Response))
       return true if defined?(ActionView) && value.is_a?(ActionView::Helpers::FormBuilder)
 


### PR DESCRIPTION
On trying to upgrade to Rails 7.2, I was experiencing

    [SystemStackError: stack level too deep (SystemStackError)]

On debugging, I found the object triggering this was an instance of ActiveRecord::Transaction:

```ruby
=> #<ActiveRecord::Transaction:0x00000001211be2a8
 @internal_transaction=
  #<ActiveRecord::ConnectionAdapters::RealTransaction:0x0000000121b1a298
   @callbacks=nil,
   @connection=#<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x0000000000ec40 env_name="development" role=:writing>,
   @dirty=false,
   @instrumenter=
    #<ActiveRecord::ConnectionAdapters::TransactionInstrumenter:0x00000001211be258
     @base_payload=
      {:connection=>#<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x0000000000ec40 env_name="development" role=:writing>,
       :transaction=>#<ActiveRecord::Transaction:0x00000001211be2a8 ...>},
     @handle=nil,
     @payload=nil,
     @started=false>,
   @isolation_level=nil,
   @joinable=true,
   @lazy_enrollment_records=nil,
   @materialized=false,
   @records=
    [#<User REDACTED>],
   @run_commit_callbacks=true,
   @state=#<ActiveRecord::ConnectionAdapters::TransactionState:0x00000001211be348 @children=nil, @state=nil>,
   @user_transaction=#<ActiveRecord::Transaction:0x00000001211be2a8 ...>,
   @written=true>,
 @uuid=nil>
```

Adding this condition in appears to fix the problem.

I think this fixes https://github.com/dejan/rails_panel/issues/206


This kind of problem seems to be a [perennial issue](https://github.com/dejan/rails_panel/issues?q=is%3Aissue+SystemStackError) in the gem. I know that super_diff has [similar issues](https://github.com/splitwise/super_diff/issues/160) - they have a "RecursionGuard", maybe that pattern could be applied to meta_request too?