### PR TITLE
docs(readme): fix outdated Chrome Web Store URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ group :development do
 end
 ```
 
-After this, install RailsPanel extension for [Chrome](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing the extension, since it will auto-update on every new version.
+After this, install RailsPanel extension for [Chrome](https://chromewebstore.google.com/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing the extension, since it will auto-update on every new version.
 
 ## Install unpacked version
 


### PR DESCRIPTION
## What
Updates the Chrome Web Store URL from the deprecated `chrome.google.com/webstore` to the new `chromewebstore.google.com` format.

## Why
The old URL format (`chrome.google.com/webstore/detail/...`) is being deprecated and may not work properly. The new format (`chromewebstore.google.com/detail/...`) is the recommended way to link to Chrome Web Store extensions.

## Testing
- Verified the new URL redirects correctly: `curl -I chromewebstore.google.com/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg` returns 301 (redirect)
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*