### PR TITLE
docs: update Chrome Web Store URL to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ group :development do
 end
 ```
 
-After this, install RailsPanel extension for [Chrome](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing the extension, since it will auto-update on every new version.
+After this, install RailsPanel extension for [Chrome](https://chromewebstore.google.com/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg). This is recommended way of installing the extension, since it will auto-update on every new version.
 
 ## Install unpacked version
 


### PR DESCRIPTION
## Summary
- Updated 1 Chrome Web Store URL from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/`
- Google migrated the Chrome Web Store to a new domain; the old URLs redirect but should be updated for consistency

## Files changed
- `README.md`